### PR TITLE
增加func过滤器

### DIFF
--- a/filter/parser.go
+++ b/filter/parser.go
@@ -210,8 +210,21 @@ TakeValueOfPointerValue: //这里主要是考虑到有可能用的不是一级�
 			ParentNode:  t,
 			IsAnonymous: isAnonymous,
 		}
-
 		value := valueOf.Field(i)
+		if tag.Function != "" {
+			function := valueOf.MethodByName(tag.Function)
+			if !function.IsValid() {
+				if valueOf.CanAddr() {
+					function = valueOf.Addr().MethodByName(tag.Function)
+				}
+			}
+			if function.IsValid() {
+				values := function.Call([]reflect.Value{})
+				if len(values) != 0 {
+					value = values[0]
+				}
+			}
+		}
 		if value.Kind() == reflect.Ptr {
 		TakeFieldValue:
 			if value.Kind() == reflect.Ptr {

--- a/filter/tag.go
+++ b/filter/tag.go
@@ -22,6 +22,8 @@ type tag struct {
 	IsAnonymous bool
 	////为空忽略
 	Omitempty bool
+	//自定义处理函数
+	Function string
 }
 
 func newSelectTag(tagStr, selectScene, fieldName string) tag {
@@ -55,9 +57,11 @@ func newSelectTag(tagStr, selectScene, fieldName string) tag {
 					//说明选中了tag里的场景,不应该被忽略
 					tagEl.IsOmitField = false
 					tagEl.IsSelect = true
-					return tagEl
 				}
 			}
+		}
+		if strings.HasPrefix(s, "func(") {
+			tagEl.Function = s[5 : len(s)-1]
 		}
 	}
 	return tagEl
@@ -102,6 +106,9 @@ func newOmitTag(tagStr, omitScene, fieldName string) tag {
 					return tagEl
 				}
 			}
+		}
+		if strings.HasPrefix(s, "func(") {
+			tagEl.Function = s[5 : len(s)-1]
 		}
 	}
 	return tagEl

--- a/test/main.go
+++ b/test/main.go
@@ -38,10 +38,18 @@ type Us struct {
 	//Uu   Uu       `json:"uu,select(h),omit(h)"`
 	//S    []string `json:"s,select(h)"`
 
-	BB [3]byte `json:"bb,select(all)"`
+	BB      [3]byte `json:"bb,select(all)"`
+	Avatar  []byte  `json:"avatar,select(all),func(GetAvatar)"`
+	Avatar2 []byte  `json:"avatar2,select(all),func(GetAvatar2)"`
+	UID     UID     `json:"uid,select(all)"`
+	UIDs    UIDs    `json:"uids,select(all)"`
+}
 
-	UID  UID  `json:"uid,select(all)"`
-	UIDs UIDs `json:"uids,select(all)"`
+func (u Us) GetAvatar() string {
+	return string(u.Avatar[:]) + ".jpg"
+}
+func (u *Us) GetAvatar2() string {
+	return string(u.Avatar[:]) + ".jpg"
 }
 
 func newUs() Us {
@@ -64,13 +72,16 @@ func main() {
 		B:          []byte(`{"a":"1"}`),
 		UID:        UID{1, 3, 4},
 		UIDs:       UIDs{1, 23, 55},
+		Avatar:     []byte("uuid"),
+		Avatar2:    []byte("uuid2"),
 	}
 
 	//fmt.Println(mustJson(u))
 	//fmt.Println(filter.Omit("h", u))
 	fmt.Println(filter.Select("all", u))
-
 	fmt.Println(filter.Omit("all", u))
+	fmt.Println(filter.Select("all", &u))
+	fmt.Println(filter.Omit("all", &u))
 	TestSlice()
 	TestMap()
 	TestU()


### PR DESCRIPTION
可以用来对某些字段进行处理或者实现其他更灵活的功能

如果接收器为指针类型，必须要传结构体的指针才能正常调用接收器 `filter.Select("all", &u)`