### PR TITLE
修复传入数组指针时引发PANIC的BUG, 修复递归时传值导致指针丢失的BUG, 修正部分测试用例

### DIFF
--- a/filter/filter.go
+++ b/filter/filter.go
@@ -1,6 +1,9 @@
 package filter
 
-import "fmt"
+import (
+	"fmt"
+	"reflect"
+)
 
 type Filter struct {
 	node *fieldNodeTree
@@ -16,7 +19,7 @@ func jsonFilter(selectScene string, el interface{}, isSelect bool) Filter {
 		Key:        "",
 		ParentNode: nil,
 	}
-	tree.parseAny("", selectScene, el, isSelect)
+	tree.parseAny("", selectScene, reflect.ValueOf(el), isSelect)
 	return Filter{
 		node: tree,
 	}

--- a/filter/parser.go
+++ b/filter/parser.go
@@ -10,12 +10,12 @@ type tagInfo struct {
 	omit bool //表示这个字段忽略
 }
 
-func (t *fieldNodeTree) parseAny(key, scene string, el interface{}, isSelect bool) {
-	typeOf := reflect.TypeOf(el)
-	valueOf := reflect.ValueOf(el)
+func (t *fieldNodeTree) parseAny(key, scene string, valueOf reflect.Value, isSelect bool) {
+	typeOf := valueOf.Type()
 TakePointerValue: //取指针的值
 	switch typeOf.Kind() {
 	case reflect.Ptr: //如果是指针类型则取地址重新判断类型
+		valueOf = valueOf.Elem()
 		typeOf = typeOf.Elem()
 		goto TakePointerValue
 	case reflect.Struct:
@@ -143,7 +143,7 @@ takeVMap:
 			nodeTree.IsNil = true
 			t.AddChild(nodeTree)
 		} else {
-			nodeTree.parseAny(k, scene, val.Interface(), isSelect)
+			nodeTree.parseAny(k, scene, val, isSelect)
 			t.AddChild(nodeTree)
 		}
 	}
@@ -248,7 +248,7 @@ TakeValueOfPointerValue: //这里主要是考虑到有可能用的不是一级�
 			}
 		}
 
-		tree.parseAny(tag.UseFieldName, scene, value.Interface(), isSelect)
+		tree.parseAny(tag.UseFieldName, scene, value, isSelect)
 
 		if t.IsAnonymous {
 			t.AnonymousAddChild(tree)
@@ -310,7 +310,7 @@ func parserSliceOrArray(typeOf reflect.Type, valueOf reflect.Value, t *fieldNode
 			node.IsNil = true
 			t.AddChild(node)
 		} else {
-			node.parseAny("", scene, val.Interface(), isSelect)
+			node.parseAny("", scene, val, isSelect)
 			t.AddChild(node)
 		}
 	}

--- a/filter/parser.go
+++ b/filter/parser.go
@@ -14,7 +14,7 @@ func (t *fieldNodeTree) parseAny(key, scene string, valueOf reflect.Value, isSel
 	typeOf := valueOf.Type()
 TakePointerValue: //取指针的值
 	switch typeOf.Kind() {
-	case reflect.Ptr: //如果是指针类型则取地址重新判断类型
+	case reflect.Ptr: //如果是指针类型则取值重新判断类型
 		valueOf = valueOf.Elem()
 		typeOf = typeOf.Elem()
 		goto TakePointerValue
@@ -110,12 +110,6 @@ func getSelectTag(scene string, pkgInfo string, i int, typeOf reflect.Type) tagI
 }
 
 func parserMap(valueOf reflect.Value, t *fieldNodeTree, scene string, isSelect bool) {
-
-takeVMap:
-	if valueOf.Kind() == reflect.Ptr {
-		valueOf = valueOf.Elem()
-		goto takeVMap
-	}
 	keys := valueOf.MapKeys()
 	if len(keys) == 0 { //空map情况下解析为{}
 		t.Val = struct{}{}
@@ -165,18 +159,6 @@ func parserBaseType(valueOf reflect.Value, t *fieldNodeTree, key string) {
 }
 
 func parserStruct(typeOf reflect.Type, valueOf reflect.Value, t *fieldNodeTree, scene string, key string, isSelect bool) {
-
-TakeValueOfPointerValue: //这里主要是考虑到有可能用的不是一级指针，如果是***int 等多级指针就需要不断的取值
-	if valueOf.Kind() == reflect.Ptr {
-		if valueOf.IsNil() {
-			t.IsNil = true
-			return
-		} else {
-			valueOf = valueOf.Elem()
-			goto TakeValueOfPointerValue
-		}
-	}
-
 	if valueOf.CanConvert(timeTypes) { //是time.Time类型或者底层是time.Time类型
 		t.Key = key
 		t.Val = valueOf.Interface()
@@ -263,7 +245,6 @@ TakeValueOfPointerValue: //这里主要是考虑到有可能用的不是一级�
 }
 
 func parserSliceOrArray(typeOf reflect.Type, valueOf reflect.Value, t *fieldNodeTree, scene string, key string, isSelect bool) {
-
 	val1 := valueOf.Interface()
 	ok := valueOf.CanConvert(byteTypes)
 	if ok {

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module github.com/liu-cn/json-filter
 
 go 1.17
 
-require (
-	github.com/liu-cn/pkg v0.0.0-20221218135636-865c46b102ea
-)
+require github.com/liu-cn/pkg v0.0.0-20221218135636-865c46b102ea

--- a/test/main.go
+++ b/test/main.go
@@ -64,7 +64,6 @@ func newUs() Us {
 }
 
 func main() {
-
 	//var bb = []byte(`{"a":"1"}`)
 	u := Us{
 		BB:         [3]byte{1, 2, 4},
@@ -75,7 +74,9 @@ func main() {
 		Avatar:     []byte("uuid"),
 		Avatar2:    []byte("uuid2"),
 	}
-
+	list := []Us{u, u, u}
+	fmt.Println(filter.Omit("1", &list))
+	//return
 	fmt.Println(mustJson(u))
 	//fmt.Println(filter.Omit("h", u))
 	//fmt.Println(filter.Select("all", u))


### PR DESCRIPTION
### 1. 修复传入数组指针时引发PANIC的BUG
```go
case reflect.Ptr: //如果是指针类型则取地址重新判断类型
    valueOf = valueOf.Elem() // 缺少这一行，valueOf并没有去掉一层指针导致parserSliceOrArray时调用valueOf.Len()发生PANIC。parserSliceOrArray中没有取值操作，我把取值的操作提到前面来了，parserStruct和parserMap中重复的取值代码删掉就可以了
    typeOf = typeOf.Elem()
    goto TakePointerValue
```
### 2. 修复递归时传值导致指针丢失的BUG
```go
func (t *fieldNodeTree) parseAny(key, scene string, valueOf reflect.Value, isSelect bool) {
    typeOf := valueOf.Type()
.....
}
```
调用parseAny时就开始传入reflect.Value类型，在传参过程中避免使用Value.Interface()，防止指针丢失，进而防止指针接收器无法调用
### 3. 修正部分测试用例